### PR TITLE
feat: update url for all suites

### DIFF
--- a/gemini.js
+++ b/gemini.js
@@ -24,7 +24,7 @@ module.exports = (gemini, options) => {
 function decorateUrl(data, config) {
     const suite = data.suite;
 
-    if (!suite.hasOwnProperty('url')) {
+    if (suite.url === null) {
         return;
     }
 

--- a/lib/url-updater.js
+++ b/lib/url-updater.js
@@ -10,7 +10,7 @@ const removeEmptyQueryParams = (query) => _.filter(query, (queryParam) => {
 function extendQuery(urlQuery, queryParams) {
     return queryParams.reduce((result, param) => {
         result[param.name] = param.mode !== 'override' && result[param.name]
-            ? _.concat([], result[param.name], param.value)
+            ? _([]).concat(result[param.name], param.value).uniq().value()
             : param.value;
 
         return result;

--- a/test/gemini.js
+++ b/test/gemini.js
@@ -50,20 +50,10 @@ describe('url-decorator/gemini', () => {
         assert.equal(data.suite.url, 'http://suite/updated/url');
     });
 
-    it('should decorate suite url  if suite hasn\'t own url', () => {
-        const data = {suite: {}};
-
-        plugin(gemini, {});
-        gemini.emit(gemini.events.BEGIN_SUITE, data);
-
-        assert.notCalled(urlUpdater.updateUrl);
-    });
-
-    it('should not decorate suite if suite url exists only in prototype', () => {
-        const proto = {url: 'rootUrl'};
-        const suite = Object.create(proto);
-
-        const data = {suite};
+    it('should not decorate suite url if suite url is null', () => {
+        const data = {suite: {
+            url: null
+        }};
 
         plugin(gemini, {});
         gemini.emit(gemini.events.BEGIN_SUITE, data);

--- a/test/lib/url-updater.js
+++ b/test/lib/url-updater.js
@@ -44,6 +44,16 @@ describe('url-updater', () => {
         });
     });
 
+    it('should extend url only with uniq parameters', () => {
+        const query = [
+            {name: 'text', value: 'foo'},
+            {name: 'text', value: 'foo'}
+        ];
+        const result = updateUrl(sourceUrl, query);
+
+        assert.equal(result, '/?text=text&text=foo');
+    });
+
     it('should override parameters if parameter mode is "override"', () => {
         const query = [{name: 'text', value: 'foo', mode: 'override'}];
 


### PR DESCRIPTION
Before plugin changed urls only for suites that has own 'url' property
Fixed adding duplicated url parameters with the same values